### PR TITLE
feat: adopt herdr & extract personal values into user attrset

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,11 @@
+# Onboarding is done; keep settings fixed.
+onboarding = false
+
+[theme]
+name = "terminal"
+
+[ui.toast]
+delivery = "herdr"
+
+[session]
+resume_agent_on_restore = true

--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -1,7 +1,10 @@
 /// Zelllij configuration
-/// - default_mode  : locked
 default_shell "zsh"
 default_layout "default"
 theme "flexoki-light"
 default_mode "locked"
+// Drop pane borders/title rows to reclaim space
+pane_frames false
+// ASCII-only UI for higher info density
+simplified_ui true
 

--- a/.config/zellij/layouts/default.kdl
+++ b/.config/zellij/layouts/default.kdl
@@ -1,13 +1,17 @@
+// Single compact-bar (bottom) instead of tab-bar + status-bar: 2 rows -> 1
 layout {
-    pane size=1 borderless=true {
-        plugin location="tab-bar"
-    }
     pane split_direction="vertical" {
-        pane
-        pane
+        pane size="50%" command="claude"
+        pane split_direction="horizontal" {
+            pane command="nvim"
+            pane size=3
+        }
     }
     pane size=1 borderless=true {
-        plugin location="status-bar"
+        plugin location="compact-bar" {
+            // tooltip key expands the keybind hints only when pressed
+            tooltip "F1"
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,18 @@ home # custom home-manager switch command.
 
 ### Appendix
 
-Customize the following fields in `home.nix` for your own environment.
+Customize the `user` attribute set in `flake.nix` for your own environment.
+`home.homeDirectory` is derived from `username`, and the git/jujutsu commit
+author name and email are derived from `author`.
 
 ```nix
-home.username
-home.homeDirectory
-programs.git.settings.user.name
-programs.git.settings.user.email
-programs.jujutsu.settings.user.name
-programs.jujutsu.settings.user.email
+user = {
+  username = "yuki"; # login name → home dir, home-manager flake target
+  author = {
+    name = "yuki"; # git/jj commit author
+    email = "your-email@example.com";
+  };
+};
 ```
 
 #### Windows + WezTerm

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "herdr": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1783291009,
+        "narHash": "sha256-fYe1sHGXeB8xyKNivwa4IX7+C/joymOtEQm4rqhqvj8=",
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "rev": "b04c6496a8c08059b8cc83ab29a51023f16c76cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -41,7 +59,7 @@
     "jj-starship": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1769370163,
@@ -59,6 +77,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1766840161,
         "narHash": "sha256-Ss/LHpJJsng8vz1Pe33RSGIWUOcqM1fjrehjUkdrWio=",
         "owner": "NixOS",
@@ -73,7 +107,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1780749050,
         "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
@@ -91,9 +125,10 @@
     },
     "root": {
       "inputs": {
+        "herdr": "herdr",
         "home-manager": "home-manager",
         "jj-starship": "jj-starship",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # Starship prompt module for Git and Jujutsu
-    jj-starship = {
-      url = "github:dmmulroy/jj-starship";
-    };
+    jj-starship.url = "github:dmmulroy/jj-starship";
+    # Terminal agent multiplexer
+    herdr.url = "github:ogulcancelik/herdr";
   };
 
   outputs =
@@ -19,12 +19,14 @@
       nixpkgs,
       home-manager,
       jj-starship,
+      herdr,
       ...
     }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
       jj-starship-pkg = jj-starship.packages.${system}.default;
+      herdr-pkg = herdr.packages.${system}.default;
     in
     {
       homeConfigurations."yuki" = home-manager.lib.homeManagerConfiguration {
@@ -36,7 +38,7 @@
 
         # Optionally use extraSpecialArgs
         # to pass through arguments to home.nix
-        extraSpecialArgs = { inherit jj-starship-pkg; };
+        extraSpecialArgs = { inherit jj-starship-pkg herdr-pkg; };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,16 @@
       pkgs = nixpkgs.legacyPackages.${system};
       jj-starship-pkg = jj-starship.packages.${system}.default;
       herdr-pkg = herdr.packages.${system}.default;
+      user = {
+        username = "yuki"; # home dir, home-manager flake target
+        author = {
+          name = "yuki"; # git/jj commit author
+          email = "64290748+takagiyuuki@users.noreply.github.com";
+        };
+      };
     in
     {
-      homeConfigurations."yuki" = home-manager.lib.homeManagerConfiguration {
+      homeConfigurations.${user.username} = home-manager.lib.homeManagerConfiguration {
         inherit pkgs;
 
         # Specify your home configuration modules here, for example,
@@ -38,7 +45,7 @@
 
         # Optionally use extraSpecialArgs
         # to pass through arguments to home.nix
-        extraSpecialArgs = { inherit jj-starship-pkg herdr-pkg; };
+        extraSpecialArgs = { inherit jj-starship-pkg herdr-pkg user; };
       };
     };
 }

--- a/home.nix
+++ b/home.nix
@@ -3,6 +3,7 @@
   pkgs,
   jj-starship-pkg,
   herdr-pkg,
+  user,
   ...
 }:
 {
@@ -14,8 +15,8 @@
       "claude-code"
     ];
   home = {
-    username = "yuki";
-    homeDirectory = "/home/yuki";
+    username = user.username;
+    homeDirectory = "/home/${user.username}";
     stateVersion = "25.11"; # Please read the comment before changing.
     packages = with pkgs; [
       # Compiler
@@ -146,8 +147,8 @@
       enable = true;
       settings = {
         user = {
-          name = "yuki";
-          email = "64290748+takagiyuuki@users.noreply.github.com";
+          name = user.author.name;
+          email = user.author.email;
         };
         core.editor = "nvim";
         "credential \"https://github.com\"" = {
@@ -159,8 +160,8 @@
       enable = true;
       settings = {
         user = {
-          name = "yuki";
-          email = "64290748+takagiyuuki@users.noreply.github.com";
+          name = user.author.name;
+          email = user.author.email;
         };
         ui = {
           editor = "nvim";

--- a/home.nix
+++ b/home.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   jj-starship-pkg,
+  herdr-pkg,
   ...
 }:
 {
@@ -28,7 +29,8 @@
       gh
       jjui
       # Terminal Multiplexer
-      zellij
+      zellij # kept as fallback while trialing herdr
+      herdr-pkg
       # cli tools
       eza
       ripgrep
@@ -113,6 +115,7 @@
       ".config/wezterm".source = ./.config/wezterm;
       ".config/starship.toml".source = ./.config/starship/starship.toml;
       ".config/zellij/".source = ./.config/zellij;
+      ".config/herdr/config.toml".source = ./.config/herdr/config.toml;
       ".config/git/ignore".source = ./.config/git/ignore;
       # Global config
       ".tflint.hcl".source = ./.tflint.hcl;
@@ -184,6 +187,19 @@
             exec zsh -l
           fi
           return $exit_code
+        }
+
+        # Launch zellij in an interactively chosen directory.
+        # Layout panes inherit this cwd, so nvim/claude start there.
+        zj() {
+          [[ -n "$ZELLIJ" ]] && { echo "already inside zellij" >&2; return 1; }
+          local dir="$1"
+          if [[ -z "$dir" ]]; then
+            # Search roots: dotfiles itself + project dirs under ~/dev. Adjust to taste.
+            dir=$( { echo "$HOME/dotfiles"; fd --type d --max-depth 2 . "$HOME/dev"; } | fzf ) || return
+          fi
+          cd "$dir" || return
+          zellij
         }
       '';
     };


### PR DESCRIPTION
## Summary
- Add herdr multiplexer (input, package, config, zellij as fallback)
- Extract personal values (username / git・jj author) into a `user` attrset in flake.nix

## Test
- `home-manager switch` succeeds